### PR TITLE
Replace gdebi with apt in project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,17 +588,13 @@ For using this feature with ytdl, set YTDL path to automatic or write full path 
 
 2. Arch Users can also get package from AUR. [Latest release](https://aur.archlinux.org/packages/kawaii-player/), thanks to **Nocipher** and [git-version](https://aur.archlinux.org/packages/kawaii-player-git/), thanks to **SolarAquarion**.
 
-3. For Ubuntu or Debian based distro.
+3. For Ubuntu or Debian based distros.
 	
-	- Users can directly go to Release section and download appropriate .deb package and install it using
+	- Users can directly go to Release section, download appropriate .deb package, and install it using
  
-			sudo gdebi pkg_name.deb. 
+			sudo apt install ./kawaii-player-<version>.deb
 
-		If 'gdebi' is not installed then install it using 
-
-			'sudo apt-get install gdebi'. 
-
-	- If user wants to install the application directly from source:
+	- If a user wants to install the application directly from source:
 		
 			$ git clone https://github.com/kanishka-linux/kawaii-player
              
@@ -609,9 +605,9 @@ For using this feature with ytdl, set YTDL path to automatic or write full path 
             
 			$ python3 create_deb.py
 		
-			Above three steps will create .deb package from latest source, which users can install using gdebi.
+			The above steps will create a .deb package from latest source, which users can install using apt.
 				
-	- **gdebi** will resolve all the dependencies while installing the package. Normally **dpkg -i** is used for installing .deb package in Debian based distros, but 'dpkg' won't install dependencies automatically, which users have to install manually as per instructions given below. Hence try to use **gdebi** for convenience.
+	- Specifying the path to the .deb is important when installing, otherwise apt will look for the package `kawaii‑player‑<version>.deb` online instead of the working directory.
 	
 	- PyQt5 available in ubuntu repository is normally older compared to latest release and packages QtWebKit (which has been deprecated since Qt-5.6) instead of QtWebEngine. If user wants to try the application with latest PyQt5 version with QtWebEngine as browser backend, then they should install the application first as per the steps given above and then they should use following command to install PyQt5 using pip (only possible for 64-bit systems).
 	

--- a/ubuntu/create_deb.py
+++ b/ubuntu/create_deb.py
@@ -28,6 +28,9 @@ usr_share = os.path.join(dest_dir,'usr','share','applications')
 usr_bin = os.path.join(dest_dir,'usr','bin')
 usr_share_kawaii = os.path.join(dest_dir,'usr','share','kawaii-player')
 
+class DpkgDebError(Exception):
+	pass
+
 if dest_dir:
 	if os.path.exists(dest_dir):
 		shutil.rmtree(dest_dir)
@@ -38,8 +41,14 @@ if dest_dir:
 	shutil.copy(exec_file,usr_bin)
 	shutil.copy(desk_file,usr_share)
 	shutil.copytree(src_dir,usr_share_kawaii)
-	subprocess.call(['dpkg-deb','--build',dest_dir])
-	deb_pkg = os.path.basename(dest_dir)+'.deb'
-	print('deb package created successfully in current directory. Now install the package using command: \n\nsudo gdebi {0}\n\n'.format(deb_pkg))
+	dpkg_errcode = subprocess.call(['dpkg-deb','--build',dest_dir])
+	deb_pkg = './'+os.path.basename(dest_dir)+'.deb'
+	if not dpkg_errcode:
+		if os.path.exists(deb_pkg):
+			print('.deb package created successfully in current directory. Now install the package using command: \n\nsudo apt install {}\n\n'.format(deb_pkg))
+		else:
+			raise FileNotFoundError('{} not found'.format(deb_pkg))
+	else:
+		raise DpkgDebError
 else:
 	print('no version number in control file')


### PR DESCRIPTION
Modern apt versions since apt 1.1 (2015) support local .deb installation if a full or relative path is provided, so gdebi is not required.

Also some minor grammatical corrections around the touched area

https://mvogt.wordpress.com/2015/11/30/apt-1-1-released/